### PR TITLE
Migrate to prockpoints.store

### DIFF
--- a/.github/workflows/reacto.yml
+++ b/.github/workflows/reacto.yml
@@ -32,7 +32,7 @@ jobs:
       shell: bash
     - run: npm run build --if-present
 
-    - run: echo prockpoints.gay > build/CNAME
+    - run: echo prockpoints.store > build/CNAME
 
     - name: SEND IT TO PAGES HQ PLEASE
       uses: peaceiris/actions-gh-pages@v3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prockpoints",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "homepage": "https://prockpoints.store",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prockpoints",
   "version": "1.1.1",
-  "homepage": "https://prockpoints.gay",
+  "homepage": "https://prockpoints.store",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/points.js
+++ b/src/points.js
@@ -65,7 +65,7 @@ function App() {
                 <div className="content">
                     <div className="header">
                         <h1>Welcome to<br/>
-                        <WobbleText textToWobble={"ProckPoints.Gay"}/>
+                        <WobbleText textToWobble={"ProckPoints.Store"}/>
                         </h1>
                     </div>
                     <p>


### PR DESCRIPTION
The old domain expired I guess so I bought the cheapest domain I could for three dollars. 

It points at github and I switched around the domain stuff in here.

I think if you change the domain in the settings to `prockpoints.store` and then hit merge it should be all good to go.